### PR TITLE
Assign sequential IDs, and only for the objects that need them

### DIFF
--- a/jsog3/jsog.py
+++ b/jsog3/jsog.py
@@ -1,4 +1,5 @@
 import json
+import itertools
 
 def dump(*args, **kwargs):
 	"""Identical to json.dump(), but produces JSOG"""
@@ -29,15 +30,19 @@ def encode(original):
 
 	# For every object seen so far, maps stringified id() to the object
 	sofar = {}
+	next_id = itertools.count()
 
 	def doEncode(original):
 		def encodeObject(original):
-			originalId = str(id(original))
+			originalId = id(original)
+			previous = sofar.get(originalId, None)
+			if previous is not None:
+				previous_id = previous.get('@id', None)
+				if previous_id is None:
+					previous_id = previous["@id"] = str(next(next_id))
+				return { '@ref': previous_id }
 
-			if originalId in sofar:
-				return { '@ref': originalId }
-
-			result = sofar[originalId] = { '@id': originalId }
+			result = sofar[originalId] = {}
 
 			for key, value in original.items():
 				result[key] = doEncode(value)

--- a/test_jsog.py
+++ b/test_jsog.py
@@ -16,9 +16,11 @@ class TestJSOG(unittest.TestCase):
 		self.assertNotEqual('@ref' in inner1, '@ref' in inner2)
 
 		if '@id' in inner1:
-			self.assertEqual(inner1['@id'], inner2['@ref'])
+			self.assertEqual('0', inner1['@id'])
+			self.assertEqual('0', inner2['@ref'])
 		else:
-			self.assertEqual(inner1['@ref'], inner2['@id'])
+			self.assertEqual('0', inner2['@id'])
+			self.assertEqual('0', inner1['@ref'])
 
 	def test_decode_reference(self):
 		JSOGIFIED = '{"@id":"1","foo":"foo","inner1":{"@id":"2","bar":"bar"},"inner2":{"@ref":"2"}}'
@@ -35,9 +37,11 @@ class TestJSOG(unittest.TestCase):
 
 		encoded = jsog.encode(thing)
 
-		self.assertTrue(encoded['@id'])
-		self.assertTrue(encoded['me']['@ref'] == encoded['@id'])
-		self.assertTrue(encoded['list'][0]['@ref'] == encoded['@id'])
+		self.assertEqual(encoded, {
+			'@id': '0',
+			'me': { '@ref': '0' },
+			'list': [ { '@ref': '0' } ],
+		})
 
 	def test_decode_circular(self):
 		thing = {}


### PR DESCRIPTION
This PR modifies the serialization stage so that:
  - `@id` is only added to objects that are actually repeated.

    Advantages:

      - Smaller size in memory/disk/network
      - Reducing the noise makes it more human-readable

  - The values of `@id` are assigned sequentially.

    Advantages:

      - Smaller size in memory/disk/network
      - Repeatable IDs make it easier to write tests
      - Avoids leaking internal pointers